### PR TITLE
Fix on Ubuntu 20.04

### DIFF
--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -46,6 +46,7 @@ systemctl stop xrdp-sesman
 
 # Configure the installed XRDP ini files.
 # use vsock transport.
+sed -i_orig -e 's/use_vsock=false/use_vsock=true/g' /etc/xrdp/xrdp.ini
 sed -i_orig -e 's/port=3389/port=vsock:\/\/-1:3389/g' /etc/xrdp/xrdp.ini
 # use rdp security.
 sed -i_orig -e 's/security_layer=negotiate/security_layer=rdp/g' /etc/xrdp/xrdp.ini


### PR DESCRIPTION
I recently installed a new Ubuntu 20.04 for testing purposes, I ran the script and it didn't work. So I started to compare your version vs the 18.04 and I changed the following in the file `/etc/xrdp/xrdp.ini` and it works.

`
use_vsock=true
`

I'll be happy if it works for you.