### PR TITLE
Make blacklist filename consistent

### DIFF
--- a/ubuntu/20.04/install.sh
+++ b/ubuntu/20.04/install.sh
@@ -75,15 +75,13 @@ sed -i -e 's/FuseMountName=thinclient_drives/FuseMountName=shared-drives/g' /etc
 sed -i_orig -e 's/allowed_users=console/allowed_users=anybody/g' /etc/X11/Xwrapper.config
 
 # Blacklist the vmw module
-if [ ! -e /etc/modprobe.d/blacklist_vmw_vsock_vmci_transport.conf ]; then
-cat >> /etc/modprobe.d/blacklist_vmw_vsock_vmci_transport.conf <<EOF
-blacklist vmw_vsock_vmci_transport
-EOF
+if [ ! -e /etc/modprobe.d/blacklist-vmw_vsock_vmci_transport.conf ]; then
+  echo blacklist vmw_vsock_vmci_transport" > /etc/modprobe.d/blacklist-vmw_vsock_vmci_transport.conf
 fi
 
 #Ensure hv_sock gets loaded
 if [ ! -e /etc/modules-load.d/hv_sock.conf ]; then
-echo "hv_sock" > /etc/modules-load.d/hv_sock.conf
+  echo "hv_sock" > /etc/modules-load.d/hv_sock.conf
 fi
 
 # Configure the policy xrdp session


### PR DESCRIPTION
All blocklist files in  `/etc/modprobe.d` start with `blacklist-`. This PR makes the new filename consistent with the existing ones.

I took the freedom to indent the contents of the if branch to make the script a bit more readable.